### PR TITLE
link: fix linkedin href

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
                   You can also add me on
                   <a target="_blank" title="Go to Facebook" class="Facebook" href="https://www.facebook.com/augustoemlazaro">Facebook</a>
                   , make contact on
-                  <a target="_blank" title="Go to Linkedin" class="linkedin" href="www.linkedin.com/in/augustolazaro">Linkedin</a>
+                  <a target="_blank" title="Go to Linkedin" class="linkedin" href="https://www.linkedin.com/in/augustolazaro">Linkedin</a>
                   and follow me on
                   <a target="_blank" title="Go to Github" class="github" href="https://github.com/augustolazaro">Github</a>
                 </p>


### PR DESCRIPTION
Instead of linking to your account, it was just being appended to the main url:
`http://augustolazaro.me/www.linkedin.com/in/augustolazaro`